### PR TITLE
Fix reversed byte order in custom file protocol

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/util/ByteUtil.java
+++ b/core/src/main/java/net/pl3x/map/core/util/ByteUtil.java
@@ -31,17 +31,17 @@ public class ByteUtil {
     }
 
     public static byte[] toBytes(int packed) {
-        byte[] bytes = new byte[4];
-        for (int i = 0; i < 4; i++) {
-            bytes[i] = (byte) (packed >>> (i * 8));
+        byte[] bytes = new byte[Integer.BYTES];
+        for (int i = 0; i < Integer.BYTES; i++) {
+            bytes[i] = (byte) (packed >>> (Byte.SIZE * (Integer.BYTES - 1 - i)));
         }
         return bytes;
     }
 
     public static int getInt(@NotNull ByteBuffer buffer, int index) {
         int value = 0;
-        for (int i = 0; i < 4; i++) {
-            value |= (buffer.get(index + i) & 0xFF) << (i * 8);
+        for (int i = 0; i < Integer.BYTES; i++) {
+            value |= (buffer.get(index + i) & 0xFF) << (Byte.SIZE * (Integer.BYTES - 1 - i));
         }
         return value;
     }

--- a/webmap/src/palette/BlockInfo.ts
+++ b/webmap/src/palette/BlockInfo.ts
@@ -1,6 +1,9 @@
 import {Block} from "./Block";
 
 export class BlockInfo {
+    public readonly BYTE_SIZE: number = 8;
+    public readonly INTEGER_BYTES: number = 4;
+
     private readonly _data: Uint8Array;
 
     constructor(data: Uint8Array) {
@@ -17,8 +20,8 @@ export class BlockInfo {
 
     private getInt(position: number): number {
         let val: number = 0;
-        for (let i: number = 0; i < 4; i++) {
-            val |= (this._data[position + i] & 0xFF) << (i * 8);
+        for (let i: number = 0; i < this.INTEGER_BYTES; i++) {
+            val |= (this._data[position + i] & 0xFF) << (this.BYTE_SIZE * ((this.INTEGER_BYTES - 1) - i));
         }
         return val;
     }


### PR DESCRIPTION
Before, the packed integer was being turned into a reversed byte array. This isn't really an issue as long as it's converted back into a packed integer using the same logic.

`settings.web-directory.read-only` will need to be set to `false` in the config when updating Pl3xMap to the version with this fix, since it includes changes to the webmap files.

Will be merged when updating to the next future minecraft update.