### PR TITLE
fix zoom speed issue on linux with chrome based browsers

### DIFF
--- a/webmap/src/Pl3xMap.ts
+++ b/webmap/src/Pl3xMap.ts
@@ -1,3 +1,4 @@
+import * as L from "leaflet";
 import {Settings} from "./settings/Settings";
 import {ControlManager} from "./control/ControlManager";
 import {PlayerManager} from "./player/PlayerManager";
@@ -57,9 +58,19 @@ export class Pl3xMap {
         getJSON('tiles/settings.json').then((json) => {
             this._settings = json as Settings;
             document.title = this._settings.lang.title;
-            //this.map.options.zoomSnap = json.zoom.snap;
-            //this.map.options.zoomDelta = json.zoom.delta;
-            //this.map.options.wheelPxPerZoomLevel = json.zoom.wheel;
+
+            // these get weird when changed. so don't.
+            this.map.options.zoomSnap = 1;
+            this.map.options.zoomDelta = 1;
+
+            // chrome based browsers on linux zoom twice as fast, so we have to double the ratio
+            // effectively undoes the fix for Leaflet/Leaflet#4538 and Leaflet/Leaflet#7403
+            // https://github.com/Leaflet/Leaflet/commit/96977a19358374b0166cff049862fa1f0fed5948
+            //
+            // remove this logic when this bug gets fixed: https://issues.chromium.org/issues/40887377
+            // it seems intentional, so it might not get fixed https://issues.chromium.org/issues/40804672
+            this.map.options.wheelPxPerZoomLevel = L.Browser.linux && L.Browser.chrome ? 120 : 60;
+
             getJSON('lang/' + this._settings.lang.langFile).then((json): void => {
                 Object.entries(json).forEach((data: [string, unknown]): void => {
                     this._langPalette.set(data[0], <string>data[1]);

--- a/webmap/src/index.d.ts
+++ b/webmap/src/index.d.ts
@@ -26,6 +26,10 @@ declare global {
 }
 
 module "leaflet" {
+    export namespace Browser {
+        const linux: boolean;
+    }
+
     export function ellipse(latLng: L.LatLngExpression, radii: L.PointTuple, tilt: number, options: L.PathOptions): Ellipse;
 
     interface Ellipse extends L.Path {


### PR DESCRIPTION
starting with chrome v109 on linux they [doubled the scrollwheel delta](https://issues.chromium.org/issues/40887377), so now the browser scrolls too fast. this was an [intentional change](https://issues.chromium.org/issues/40804672) and people are happy with it, however it create a lot of unintentional bugs. one bug is that [leaflet now zooms in/out too fast](https://github.com/Leaflet/Leaflet/pull/8861) again (it jumps 2 zoom levels instead of 1). other bugs include scrolling content way too quickly, like a [select box scrolling so fast](https://jsfiddle.net/Lkgjfa1w/) you miss some options (it goes from 1-4 to 8-11 with one mousewheel tick lol)

anyways, long story short is the fix in leaflet from years ago needs to be removed. until then we can workaround it by doubling the ratio in the map options on our end when we detect linux+chrome combination.