### PR TITLE
fix Fabric mixin for player hiding for 1.21.6

### DIFF
--- a/fabric/src/main/java/net/pl3x/map/fabric/server/mixin/MixinServerPlayer.java
+++ b/fabric/src/main/java/net/pl3x/map/fabric/server/mixin/MixinServerPlayer.java
@@ -23,8 +23,9 @@
  */
 package net.pl3x.map.fabric.server.mixin;
 
-import net.minecraft.nbt.CompoundTag;
 import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.level.storage.ValueInput;
+import net.minecraft.world.level.storage.ValueOutput;
 import net.pl3x.map.fabric.server.duck.AccessServerPlayer;
 import org.jspecify.annotations.NullMarked;
 import org.spongepowered.asm.mixin.Mixin;
@@ -41,13 +42,13 @@ public class MixinServerPlayer implements AccessServerPlayer {
     private boolean hidden;
 
     @Inject(method = "addAdditionalSaveData", at = @At("TAIL"))
-    private void addAdditionalSaveData(CompoundTag compoundTag, CallbackInfo info) {
-        compoundTag.putBoolean("pl3xmap.hidden", this.hidden);
+    private void addAdditionalSaveData(ValueOutput valueOutput, CallbackInfo ci) {
+        valueOutput.putBoolean("pl3xmap.hidden", this.hidden);
     }
 
     @Inject(method = "readAdditionalSaveData", at = @At("TAIL"))
-    private void readAdditionalSaveData(CompoundTag compoundTag, CallbackInfo info) {
-        this.hidden = compoundTag.getBooleanOr("pl3xmap.hidden", false);
+    private void readAdditionalSaveData(ValueInput valueInput, CallbackInfo ci) {
+        this.hidden = valueInput.getBooleanOr("pl3xmap.hidden", false);
     }
 
     @Override


### PR DESCRIPTION
Mojang have split up the NBT classes, this fix makes the mod run on Fabric again (provided you also compile the new adventure-platform-fabric locally too, but unrelated to this)