### PR TITLE
Improve allocation rates by ~50%

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/util/Colors.java
+++ b/core/src/main/java/net/pl3x/map/core/util/Colors.java
@@ -371,6 +371,6 @@ public class Colors {
 
     @FunctionalInterface
     public interface Sampler {
-        Integer apply(Biome biome, Integer x, Integer z);
+        int apply(Biome biome, int x, int z);
     }
 }


### PR DESCRIPTION
I noticed that a significant portion of the allocations performed by Pl3xMap came from boxing an int as an Integer when using the Sampler Functional Interface. Unless I've missed something, no boxing should be required here. This should improve allocation rates by ~40-50%, as can be seen in the following Spark reports.
<img width="712" height="530" alt="after-primitive" src="https://github.com/user-attachments/assets/83a9745b-1bb7-4e2c-afad-a4e489e56e28" />
<img width="732" height="336" alt="before-boxing" src="https://github.com/user-attachments/assets/d5e6f978-4af2-4182-9fdb-4e04646f700b" />
<img width="760" height="566" alt="after-all" src="https://github.com/user-attachments/assets/ad625356-5563-4c0f-b7fb-3f2ad2f14b9d" />
<img width="750" height="582" alt="before-all" src="https://github.com/user-attachments/assets/38d9cf57-d5ca-4a78-a155-0b41c6915710" />
