### PR TITLE
Avoid spammy file writes

### DIFF
--- a/core/src/main/java/net/pl3x/map/core/renderer/task/AbstractDataTask.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/AbstractDataTask.java
@@ -53,6 +53,7 @@ public abstract class AbstractDataTask extends Task {
 
     protected final World world;
     protected final Map<String, Long> lastUpdated = new HashMap<>();
+    protected final Map<String, Long> lastHashCode = new HashMap<>();
     protected final ExecutorService executor;
     protected final String executorName;
 

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateMarkerData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateMarkerData.java
@@ -51,10 +51,17 @@ public class UpdateMarkerData extends AbstractDataTask {
 
                 long now = System.currentTimeMillis();
                 long lastUpdated = this.lastUpdated.getOrDefault(key, 0L);
+                long lastHashCode = this.lastHashCode.getOrDefault(key, 0L);
 
                 if (now - lastUpdated > Math.max(TickUtil.toMilliseconds(layer.getUpdateInterval()), 1000)) {
                     List<Marker<?>> list = new ArrayList<>(layer.getMarkers());
-                    FileUtil.writeJson(this.gson.toJson(list), this.world.getMarkersDirectory().resolve(key.replace(":", "-") + ".json"));
+                    String jsonMarkers = this.gson.toJson(list);
+                    long hashCode = jsonMarkers.hashCode();
+                    if (lastHashCode != hashCode)
+                    {
+                        FileUtil.writeJson(jsonMarkers, this.world.getMarkersDirectory().resolve(key.replace(":", "-") + ".json"));
+                    }
+                    this.lastHashCode.put(key, hashCode);
                     this.lastUpdated.put(key, now);
                 }
             } catch (Throwable t) {
@@ -62,6 +69,13 @@ public class UpdateMarkerData extends AbstractDataTask {
             }
         });
 
-        FileUtil.writeJson(this.gson.toJson(layers), this.world.getTilesDirectory().resolve("markers.json"));
+        long lastHashCode = this.lastHashCode.getOrDefault("", 0L);
+        String markersJson = this.gson.toJson(layers);
+        long hashCode = markersJson.hashCode();
+        if (lastHashCode != hashCode)
+        {
+            FileUtil.writeJson(this.gson.toJson(layers), this.world.getTilesDirectory().resolve("markers.json"));
+            this.lastHashCode.put("", hashCode);
+        }
     }
 }

--- a/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
+++ b/core/src/main/java/net/pl3x/map/core/renderer/task/UpdateSettingsData.java
@@ -30,6 +30,7 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import net.pl3x.map.core.Pl3xMap;
@@ -46,14 +47,14 @@ import org.jspecify.annotations.NullMarked;
 
 @NullMarked
 public class UpdateSettingsData extends Task {
-    private int fileTick;
     private final Gson gson = new GsonBuilder()
             //.setPrettyPrinting()
             .disableHtmlEscaping()
             .serializeNulls()
             .setLenient()
             .create();
-    private int jsonHashCache = -1;
+    
+    private HashMap<String, Long> jsonHashCache = new HashMap<>();
     private final ExecutorService executor;
 
     private CompletableFuture<Void> future;
@@ -126,7 +127,15 @@ public class UpdateSettingsData extends Task {
             settings.put("zoom", zoom);
             settings.put("ui", ui);
 
-            FileUtil.writeJson(this.gson.toJson(settings), world.getTilesDirectory().resolve("settings.json"));
+            String key = world.getName();
+            long lastHashCode = this.jsonHashCache.getOrDefault(key, 0L);
+            String worldSettingsJson = this.gson.toJson(settings);
+            long hashCode = worldSettingsJson.hashCode();
+            if (lastHashCode != hashCode)
+            {
+                FileUtil.writeJson(worldSettingsJson, world.getTilesDirectory().resolve("settings.json"));
+                this.jsonHashCache.put(key, hashCode);
+            }
 
             List<Object> renderers = new ArrayList<>();
             world.getRenderers().forEach((rendererKey, builder) -> {
@@ -185,15 +194,12 @@ public class UpdateSettingsData extends Task {
         }
 
         String json = this.gson.toJson(map);
-
-        if (jsonHashCache != json.hashCode()) {
+        long lastHashCode = this.jsonHashCache.getOrDefault("", 0L);
+        long hashCode = json.hashCode();
+        if (lastHashCode != hashCode) {
             Pl3xMap.api().getHttpdServer().getLiveDataHandler().send("settings", json);
-            jsonHashCache = json.hashCode();
-        }
-
-        if (fileTick++ >= 20) {
-            fileTick = 0;
             FileUtil.writeJson(json, FileUtil.getTilesDir().resolve("settings.json"));
+            this.jsonHashCache.put("", hashCode);
         }
     }
 }


### PR DESCRIPTION
Pl3xMap is constantly writing a number of files to disk, even on idling servers:

<img width="1039" height="133" alt="image" src="https://github.com/user-attachments/assets/789fd446-43b4-4a04-af19-22a99a43d83d" />

This PR keeps a cache of JSON hashes in the markers and tiles settings tasks so we only write down files on content change.